### PR TITLE
#14 setting monitoring grafana prometheus loki

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -94,7 +94,7 @@ docker-compose.override.yml
 .env.development.local
 .env.test.local
 .env.production.local
-docker-compose-local.yml
+docker-compose-*.yml
 
 # Application 설정 파일
 **/application-*.yml

--- a/build.gradle
+++ b/build.gradle
@@ -38,6 +38,9 @@ subprojects {
 	dependencies {
 		implementation 'org.springframework.boot:spring-boot-starter-actuator'
 
+		// validation
+		implementation 'org.springframework.boot:spring-boot-starter-validation'
+
 		// Lombok
 		compileOnly 'org.projectlombok:lombok'
 		annotationProcessor 'org.projectlombok:lombok'

--- a/eureka/src/main/resources/application.yml
+++ b/eureka/src/main/resources/application.yml
@@ -13,3 +13,14 @@ eureka:
             defaultZone: http://localhost:19090/eureka/
     instance:
         hostname: localhost
+
+
+management:
+    endpoints:
+        web:
+            exposure:
+                include: prometheus
+    prometheus:
+        metrics:
+            export:
+                enabled: true

--- a/user/src/main/java/com/coopang/user/UserApplication.java
+++ b/user/src/main/java/com/coopang/user/UserApplication.java
@@ -2,12 +2,13 @@ package com.coopang.user;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
 
-@SpringBootApplication
+@SpringBootApplication(exclude = SecurityAutoConfiguration.class) // Spring Security 인증 기능 제외
 public class UserApplication {
 
-	public static void main(String[] args) {
-		SpringApplication.run(UserApplication.class, args);
-	}
+    public static void main(String[] args) {
+        SpringApplication.run(UserApplication.class, args);
+    }
 
 }

--- a/user/src/main/java/com/coopang/user/infrastructure/security/PasswordConfig.java
+++ b/user/src/main/java/com/coopang/user/infrastructure/security/PasswordConfig.java
@@ -1,0 +1,15 @@
+package com.coopang.user.infrastructure.security;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+@Configuration
+public class PasswordConfig {
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+}

--- a/user/src/main/java/com/coopang/user/infrastructure/security/WebSecurityConfig.java
+++ b/user/src/main/java/com/coopang/user/infrastructure/security/WebSecurityConfig.java
@@ -1,0 +1,25 @@
+package com.coopang.user.infrastructure.security;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+@EnableWebSecurity // Spring Security 지원을 가능하게 함
+public class WebSecurityConfig {
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        // CSRF 설정
+        http.csrf((csrf) -> csrf.disable());
+
+        http.authorizeHttpRequests((authorizeHttpRequests) ->
+                authorizeHttpRequests
+                        .anyRequest()
+                        .permitAll());
+
+        return http.build();
+    }
+}

--- a/user/src/main/resources/logback.xml
+++ b/user/src/main/resources/logback.xml
@@ -1,17 +1,27 @@
 <configuration>
-	<appender name="LOKI" class="com.github.loki4j.logback.Loki4jAppender">
-		<http>
-			<url>http://localhost:3100/loki/api/v1/push</url>
-		</http>
-		<format>
-			<label>
-				<pattern>app=my-app,host=${HOSTNAME}</pattern>
-			</label>
-			<message class="com.github.loki4j.logback.JsonLayout" />
-		</format>
-	</appender>
+<!-- Console Appender: 콘솔로 로그 출력 -->
+<appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+	<encoder>
+		<pattern>%d{yyyy-MM-dd HH:mm:ss} %-5level [%thread] %logger{36} - %msg%n</pattern>
+	</encoder>
+</appender>
 
-	<root level="DEBUG">
-		<appender-ref ref="LOKI" />
-	</root>
+<!-- Loki Appender: Loki로 로그 전송 -->
+<appender name="LOKI" class="com.github.loki4j.logback.Loki4jAppender">
+	<http>
+		<url>http://localhost:3100/loki/api/v1/push</url>
+	</http>
+	<format>
+		<label>
+			<pattern>app=my-app,host=${HOSTNAME}</pattern>
+		</label>
+		<message class="com.github.loki4j.logback.JsonLayout" />
+	</format>
+</appender>
+
+<!-- Root Logger: 두 개의 Appender를 모두 사용 -->
+<root level="DEBUG">
+	<appender-ref ref="CONSOLE" />  <!-- 콘솔로 출력 -->
+	<appender-ref ref="LOKI" />     <!-- Loki로 전송 -->
+</root>
 </configuration>


### PR DESCRIPTION
* [Update] user server - logback.xml
  * 스프링 부트에서도 로그를 볼 수 있도록 로그를 추가 함

* [Fix] user server - Add spring-boot-starter-validation
  * user 서버의 로그 확인이 가능해져서 서버 오류 해결
    * implementation 'org.springframework.boot:spring-boot-starter-validation' 추가

* [Update] eureka server - prometheus 설정 추가

* [Update] user server - spring security 로그인 설정 일시 막기
  * 그라파나 모니터링 세팅을 하는데 있어서, spring security login 이 뜨지 않도록 처리함

* [Add] user server - PasswordConfig

* [Update] gitIngnore 수정
  * 범용적이게 docker-compose-*.yml 로 수정