### PR TITLE
[DEV-Product] 상품 재고, 재고 기록관련 CRUD 생성

### DIFF
--- a/BOOT/product/src/main/java/com/coopang/product/application/request/ProductStockDto.java
+++ b/BOOT/product/src/main/java/com/coopang/product/application/request/ProductStockDto.java
@@ -1,0 +1,10 @@
+package com.coopang.product.application.request;
+
+import java.util.UUID;
+import lombok.Data;
+
+@Data
+public class ProductStockDto {
+    private int amount;
+    private UUID orderId;
+}

--- a/BOOT/product/src/main/java/com/coopang/product/application/request/ProductStockHistoryDto.java
+++ b/BOOT/product/src/main/java/com/coopang/product/application/request/ProductStockHistoryDto.java
@@ -1,0 +1,13 @@
+package com.coopang.product.application.request;
+
+import com.coopang.product.domain.entity.ProductStockHistoryChangeType;
+import lombok.Data;
+
+@Data
+public class ProductStockHistoryDto {
+    private int productStockHistoryChangeQuantity;
+    private int productStockHistoryPreviousQuantity;
+    private int productStockHistoryCurrentQuantity;
+    private String productStockHistoryAdditionalInfo;
+    private ProductStockHistoryChangeType productStockHistoryChangeType;
+}

--- a/BOOT/product/src/main/java/com/coopang/product/application/response/ProductStockHistoryResponseDto.java
+++ b/BOOT/product/src/main/java/com/coopang/product/application/response/ProductStockHistoryResponseDto.java
@@ -1,0 +1,32 @@
+package com.coopang.product.application.response;
+
+import com.coopang.product.domain.entity.ProductStockHistoryChangeType;
+import com.coopang.product.domain.entity.ProductStockHistoryEntity;
+import java.util.UUID;
+import lombok.AccessLevel;
+import lombok.Builder;
+
+@Builder(access = AccessLevel.PRIVATE)
+public record ProductStockHistoryResponseDto(
+    UUID productStockHistoryId,
+    UUID productStockId,
+    UUID orderId,
+    int productStockHistoryChangeQuantity,
+    int productStockHistoryPreviousQuantity,
+    int productStockHistoryCurrentQuantity,
+    String productStockHistoryAdditionalInfo,
+    ProductStockHistoryChangeType productStockHistoryChangeType
+) {
+
+    public static ProductStockHistoryResponseDto of(ProductStockHistoryEntity entity){
+        return ProductStockHistoryResponseDto.builder()
+            .productStockHistoryId(entity.getProductStockHistoryId())
+            .orderId(entity.getOrderId())
+            .productStockHistoryChangeQuantity(entity.getProductStockHistoryChangeQuantity())
+            .productStockHistoryPreviousQuantity(entity.getProductStockHistoryPreviousQuantity())
+            .productStockHistoryCurrentQuantity(entity.getProductStockHistoryCurrentQuantity())
+            .productStockHistoryAdditionalInfo(entity.getProductStockHistoryAdditionalInfo())
+            .productStockHistoryChangeType(entity.getProductStockHistoryChangeType())
+            .build();
+    }
+}

--- a/BOOT/product/src/main/java/com/coopang/product/application/service/ProductService.java
+++ b/BOOT/product/src/main/java/com/coopang/product/application/service/ProductService.java
@@ -6,6 +6,7 @@ import com.coopang.product.application.request.ProductHiddenAndSaleDto;
 import com.coopang.product.application.request.ProductStockDto;
 import com.coopang.product.application.request.ProductStockHistoryDto;
 import com.coopang.product.application.response.ProductResponseDto;
+import com.coopang.product.application.response.ProductStockHistoryResponseDto;
 import com.coopang.product.domain.entity.CategoryEntity;
 import com.coopang.product.domain.entity.ProductEntity;
 import com.coopang.product.domain.entity.ProductStockEntity;
@@ -17,6 +18,7 @@ import com.coopang.product.domain.repository.ProductRepository;
 import com.coopang.product.domain.service.ProductDomainService;
 import com.coopang.product.presentation.request.BaseSearchCondition;
 import com.coopang.product.presentation.request.ProductSearchCondition;
+import com.coopang.product.presentation.request.ProductStockHistorySearchCondition;
 import com.coopang.product.presentation.request.UpdateStockRequest;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
@@ -272,7 +274,7 @@ public class ProductService {
     }
 
     @Transactional
-    public void deleteProductStockHistory(UUID productId, UUID productStockHistoryId, UUID userId, String role) {
+    public void deleteProductStockHistory(UUID productId, UUID productStockHistoryId) {
         
         ProductEntity productEntity = findByProductId(productId);
 
@@ -307,5 +309,18 @@ public class ProductService {
             productStockHistoryDto.getProductStockHistoryAdditionalInfo(),
             productStockHistoryDto.getProductStockHistoryChangeType()
         );
+    }
+
+    @Transactional(readOnly = true)
+    public Page<ProductStockHistoryResponseDto> getStockHistoriesByProductId(UUID productId, Pageable pageable) {
+
+        return productRepository.getProductStockHistoryByProductId(productId, pageable).map(ProductStockHistoryResponseDto::of);
+
+    }
+
+    @Transactional(readOnly = true)
+    public Page<ProductStockHistoryResponseDto> getStockHistoriesByProductIdWithCondition(ProductStockHistorySearchCondition condition, UUID productId, Pageable pageable) {
+
+        return productRepository.searchProductStockHistoryByProductId(condition,productId,pageable).map(ProductStockHistoryResponseDto::of);
     }
 }

--- a/BOOT/product/src/main/java/com/coopang/product/application/service/ProductService.java
+++ b/BOOT/product/src/main/java/com/coopang/product/application/service/ProductService.java
@@ -4,12 +4,14 @@ import com.coopang.apidata.application.user.enums.UserRoleEnum;
 import com.coopang.product.application.request.ProductDto;
 import com.coopang.product.application.request.ProductHiddenAndSaleDto;
 import com.coopang.product.application.request.ProductStockDto;
+import com.coopang.product.application.request.ProductStockHistoryDto;
 import com.coopang.product.application.response.ProductResponseDto;
 import com.coopang.product.domain.entity.CategoryEntity;
 import com.coopang.product.domain.entity.ProductEntity;
 import com.coopang.product.domain.entity.ProductStockEntity;
 import com.coopang.product.domain.entity.ProductStockHistoryChangeType;
 import com.coopang.product.domain.entity.ProductStockHistoryEntity;
+import com.coopang.product.domain.entity.vo.ProductStock;
 import com.coopang.product.domain.repository.CategoryRepository;
 import com.coopang.product.domain.repository.ProductRepository;
 import com.coopang.product.domain.service.ProductDomainService;
@@ -267,5 +269,43 @@ public class ProductService {
                 }
             }
         }
+    }
+
+    @Transactional
+    public void deleteProductStockHistory(UUID productId, UUID productStockHistoryId, UUID userId, String role) {
+        
+        ProductEntity productEntity = findByProductId(productId);
+
+        ProductStockEntity productStockEntity = productEntity.getProductStockEntity();
+        ProductStockHistoryEntity productStockHistoryEntity = findStockHistoryById(
+            productStockHistoryId, productStockEntity);
+
+        productStockHistoryEntity.setDeleted(true);
+        
+    }
+
+    private static ProductStockHistoryEntity findStockHistoryById(UUID productStockHistoryId,
+        ProductStockEntity productStockEntity) {
+        return productStockEntity.getProductStockHistories().stream().
+            filter(entity -> entity.getProductStockHistoryId().equals(productStockHistoryId))
+            .findFirst().orElseThrow(() -> new IllegalArgumentException("존재하지 않는 상품재고기록입니다."));
+    }
+
+    @Transactional
+    public void updateProductStockHistory(ProductStockHistoryDto productStockHistoryDto,UUID productId, UUID productStockHistoryId) {
+
+        ProductEntity productEntity = findByProductId(productId);
+
+        ProductStockEntity productStockEntity = productEntity.getProductStockEntity();
+        ProductStockHistoryEntity productStockHistoryEntity = findStockHistoryById(
+            productStockHistoryId, productStockEntity);
+
+        productStockHistoryEntity.updateProductStockHistory(
+            productStockHistoryDto.getProductStockHistoryChangeQuantity(),
+            productStockHistoryDto.getProductStockHistoryPreviousQuantity(),
+            productStockHistoryDto.getProductStockHistoryCurrentQuantity(),
+            productStockHistoryDto.getProductStockHistoryAdditionalInfo(),
+            productStockHistoryDto.getProductStockHistoryChangeType()
+        );
     }
 }

--- a/BOOT/product/src/main/java/com/coopang/product/domain/entity/ProductStockEntity.java
+++ b/BOOT/product/src/main/java/com/coopang/product/domain/entity/ProductStockEntity.java
@@ -13,6 +13,7 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.OneToOne;
 import jakarta.persistence.Table;
+import jakarta.persistence.Version;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
@@ -44,6 +45,10 @@ public class ProductStockEntity extends BaseEntity {
     @Embedded
     private ProductStock productStock;
 
+    //낙관적 락을 위한 버전 필드
+    @Version
+    private int version;
+
     @OneToMany(mappedBy = "productStockEntity", cascade = CascadeType.ALL)
     private List<ProductStockHistoryEntity> productStockHistories = new ArrayList<>();
 
@@ -63,5 +68,13 @@ public class ProductStockEntity extends BaseEntity {
             .productEntity(productEntity)
             .productStock(productStock)
             .build();
+    }
+
+    public void increaseStock(int amount) {
+        this.productStock.addStock(amount);
+    }
+
+    public void decreaseStock(int amount) {
+        this.productStock.reduceStock(amount);
     }
 }

--- a/BOOT/product/src/main/java/com/coopang/product/domain/entity/ProductStockHistoryEntity.java
+++ b/BOOT/product/src/main/java/com/coopang/product/domain/entity/ProductStockHistoryEntity.java
@@ -89,4 +89,19 @@ public class ProductStockHistoryEntity extends BaseEntity {
             .productStockHistoryAdditionalInfo(productStockHistoryAdditionalInfo)
             .build();
     }
+
+    public void updateProductStockHistory(
+         int productStockHistoryChangeQuantity,
+         int productStockHistoryPreviousQuantity,
+         int productStockHistoryCurrentQuantity,
+         String productStockHistoryAdditionalInfo,
+         ProductStockHistoryChangeType productStockHistoryChangeType
+    )
+    {
+        this.productStockHistoryChangeQuantity = productStockHistoryChangeQuantity;
+        this.productStockHistoryPreviousQuantity = productStockHistoryPreviousQuantity;
+        this.productStockHistoryCurrentQuantity = productStockHistoryCurrentQuantity;
+        this.productStockHistoryAdditionalInfo = productStockHistoryAdditionalInfo;
+        this.productStockHistoryChangeType = productStockHistoryChangeType;
+    }
 }

--- a/BOOT/product/src/main/java/com/coopang/product/domain/entity/vo/ProductStock.java
+++ b/BOOT/product/src/main/java/com/coopang/product/domain/entity/vo/ProductStock.java
@@ -30,4 +30,17 @@ public class ProductStock {
 
     }
 
+    public void addStock(int amount) {
+        if (amount < 0) {
+            throw new IllegalArgumentException("추가할 수량은 음수가 될 수 없습니다.");
+        }
+        this.value += amount;
+    }
+
+    public void reduceStock(int amount) {
+        if (this.value - amount < 0) {
+            throw new IllegalArgumentException("재고 수량이 부족합니다.");
+        }
+        this.value -= amount;
+    }
 }

--- a/BOOT/product/src/main/java/com/coopang/product/domain/repository/ProductRepository.java
+++ b/BOOT/product/src/main/java/com/coopang/product/domain/repository/ProductRepository.java
@@ -29,4 +29,5 @@ public interface ProductRepository {
 
     @Query("SELECT p FROM ProductEntity p JOIN FETCH p.productStockEntity s JOIN FETCH p.categoryEntity c")
     Page<ProductEntity> findAll(Pageable pageable);
+
 }

--- a/BOOT/product/src/main/java/com/coopang/product/domain/repository/ProductRepository.java
+++ b/BOOT/product/src/main/java/com/coopang/product/domain/repository/ProductRepository.java
@@ -1,7 +1,9 @@
 package com.coopang.product.domain.repository;
 
 import com.coopang.product.domain.entity.ProductEntity;
+import com.coopang.product.domain.entity.ProductStockHistoryEntity;
 import com.coopang.product.presentation.request.ProductSearchCondition;
+import com.coopang.product.presentation.request.ProductStockHistorySearchCondition;
 import java.util.Optional;
 import java.util.UUID;
 import org.springframework.data.domain.Page;
@@ -29,5 +31,10 @@ public interface ProductRepository {
 
     @Query("SELECT p FROM ProductEntity p JOIN FETCH p.productStockEntity s JOIN FETCH p.categoryEntity c")
     Page<ProductEntity> findAll(Pageable pageable);
+
+    Page<ProductStockHistoryEntity> getProductStockHistoryByProductId(UUID productId, Pageable pageable);
+
+    Page<ProductStockHistoryEntity> searchProductStockHistoryByProductId(
+        ProductStockHistorySearchCondition condition,UUID productId, Pageable pageable);
 
 }

--- a/BOOT/product/src/main/java/com/coopang/product/infrastructure/repository/ProductRepositoryCustom.java
+++ b/BOOT/product/src/main/java/com/coopang/product/infrastructure/repository/ProductRepositoryCustom.java
@@ -1,7 +1,9 @@
 package com.coopang.product.infrastructure.repository;
 
 import com.coopang.product.domain.entity.ProductEntity;
+import com.coopang.product.domain.entity.ProductStockHistoryEntity;
 import com.coopang.product.presentation.request.ProductSearchCondition;
+import com.coopang.product.presentation.request.ProductStockHistorySearchCondition;
 import java.util.Optional;
 import java.util.UUID;
 import javax.swing.text.html.Option;
@@ -13,5 +15,10 @@ public interface ProductRepositoryCustom {
     Optional<ProductEntity> getOneByProductId(UUID productId);
 
     Page<ProductEntity> search(ProductSearchCondition productSearchCondition, Pageable pageable);
+
+    Page<ProductStockHistoryEntity> getProductStockHistoryByProductId(UUID productId, Pageable pageable);
+
+    Page<ProductStockHistoryEntity> searchProductStockHistoryByProductId(
+        ProductStockHistorySearchCondition condition,UUID productId, Pageable pageable);
 
 }

--- a/BOOT/product/src/main/java/com/coopang/product/infrastructure/repository/ProductRepositoryCustomImpl.java
+++ b/BOOT/product/src/main/java/com/coopang/product/infrastructure/repository/ProductRepositoryCustomImpl.java
@@ -48,12 +48,12 @@ public class ProductRepositoryCustomImpl extends Querydsl4RepositorySupport impl
 
              contentQuery.selectFrom(productStockHistoryEntity)
                 .join(productStockHistoryEntity.productStockEntity)
-                .join(productEntity)
+                .join(productEntity).fetchJoin()
                 .on(productStockHistoryEntity.productStockEntity.productEntity.productId.eq(productEntity.productId))
                 .where(productEntity.productId.eq(productId))
             ,countQuery -> countQuery.selectFrom(productStockHistoryEntity)
                 .join(productStockHistoryEntity.productStockEntity)
-                .join(productEntity)
+                .join(productEntity).fetchJoin()
                 .on(productStockHistoryEntity.productStockEntity.productEntity.productId.eq(productEntity.productId))
                 .where(productEntity.productId.eq(productId))
         );
@@ -67,14 +67,14 @@ public class ProductRepositoryCustomImpl extends Querydsl4RepositorySupport impl
         return applyPagination(pageable,contentQuery ->
                 contentQuery.selectFrom(productStockHistoryEntity)
                     .join(productStockHistoryEntity.productStockEntity)
-                    .join(productEntity)
+                    .join(productEntity).fetchJoin()
                     .on(productStockHistoryEntity.productStockEntity.productEntity.productId.eq(productEntity.productId))
                     .where(productEntity.productId.eq(productId),
                         isProductStockHistoryType(condition.changeType()),
                         betweenStartDateAndEndDateByProductStockHistory(condition.startDate(),condition.endDate()))
             ,countQuery -> countQuery.selectFrom(productStockHistoryEntity)
                 .join(productStockHistoryEntity.productStockEntity)
-                .join(productEntity)
+                .join(productEntity).fetchJoin()
                 .on(productStockHistoryEntity.productStockEntity.productEntity.productId.eq(productEntity.productId))
                 .where(productEntity.productId.eq(productId),
                     isProductStockHistoryType(condition.changeType()),

--- a/BOOT/product/src/main/java/com/coopang/product/presentation/controller/ProductStockController.java
+++ b/BOOT/product/src/main/java/com/coopang/product/presentation/controller/ProductStockController.java
@@ -5,6 +5,7 @@ import com.coopang.product.application.request.ProductStockDto;
 import com.coopang.product.application.service.ProductService;
 import com.coopang.product.presentation.request.AddStockRequest;
 import com.coopang.product.presentation.request.UpdateStockRequest;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import java.util.Map;
 import java.util.UUID;
@@ -18,6 +19,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+@Tag(name = "ProductStockController API", description = "ProductStockController API")
 @RestController
 @RequestMapping("/product-stocks/v1/product")
 @RequiredArgsConstructor

--- a/BOOT/product/src/main/java/com/coopang/product/presentation/controller/ProductStockController.java
+++ b/BOOT/product/src/main/java/com/coopang/product/presentation/controller/ProductStockController.java
@@ -1,9 +1,15 @@
 package com.coopang.product.presentation.controller;
 
+import com.coopang.apiconfig.mapper.ModelMapperConfig;
+import com.coopang.product.application.request.ProductStockDto;
+import com.coopang.product.application.service.ProductService;
+import com.coopang.product.presentation.request.AddStockRequest;
 import java.util.Map;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.annotation.Secured;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -11,26 +17,56 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
-@RequestMapping("/product-stocks/v1")
+@RequestMapping("/product-stocks/v1/product")
 @RequiredArgsConstructor
 public class ProductStockController {
 
-    //private final ProductStockService productStockService;
+    private final ProductService productService;
+    private final ModelMapperConfig mapperConfig;
 
-    @PatchMapping("/product/{productId}/productStockId/{productStockId}")
-    public ResponseEntity<String> updateProductStock(
+    @Secured({"ROLE_MASTER","ROLE_HUB_MANAGER","ROLE_COMPANY"})
+    @PatchMapping("/{productId}/restock")
+    public ResponseEntity<?> addProductStock(@PathVariable UUID productId,
+        @RequestBody AddStockRequest addStockRequest) {
+
+        ProductStockDto productStockDto = mapperConfig.strictMapper().map(addStockRequest, ProductStockDto.class);
+
+        productService.addProductStock(productId,productStockDto);
+
+        return new ResponseEntity<>(HttpStatus.NO_CONTENT);
+    }
+
+    @Secured({"ROLE_MASTER","ROLE_HUB_MANAGER","ROLE_COMPANY"})
+    @PatchMapping("/{productId}/reduce")
+    public ResponseEntity<String> reduceProductStock(
         @PathVariable UUID productId,
         @PathVariable UUID productStockId,
         @RequestBody Map<String, Object> stockUpdateRequest) {
         // 상품 재고 수량 변경 로직
-        String operation = (String) stockUpdateRequest.get("operation");
-        Integer amount = (Integer) stockUpdateRequest.get("amount");
 
-        if (operation == null || amount == null || amount <= 0) {
-            return ResponseEntity.badRequest().body("Invalid request data");
-        }
-
-        //productStockService.updateStock(productId, productStockId, operation, amount);
         return ResponseEntity.ok("Stock updated successfully");
     }
+
+    @Secured({"ROLE_MASTER","ROLE_HUB_MANAGER","ROLE_COMPANY"})
+    @PatchMapping("/{productId}/rollback-increase")
+    public ResponseEntity<?> increaseProductStockByRollback(
+        @PathVariable UUID productId,
+        @PathVariable UUID productStockId,
+        @RequestBody Map<String, Object> stockUpdateRequest) {
+        // 상품 재고 수량 변경 로직
+
+        return ResponseEntity.ok("Stock updated successfully");
+    }
+
+    @Secured({"ROLE_MASTER","ROLE_HUB_MANAGER","ROLE_COMPANY"})
+    @PatchMapping("/{productId}/cancel-increase")
+    public ResponseEntity<String> increaseProductStockByCancel(
+        @PathVariable UUID productId,
+        @PathVariable UUID productStockId,
+        @RequestBody Map<String, Object> stockUpdateRequest) {
+        // 상품 재고 수량 변경 로직
+
+        return ResponseEntity.ok("Stock updated successfully");
+    }
+
 }

--- a/BOOT/product/src/main/java/com/coopang/product/presentation/controller/ProductStockController.java
+++ b/BOOT/product/src/main/java/com/coopang/product/presentation/controller/ProductStockController.java
@@ -4,6 +4,8 @@ import com.coopang.apiconfig.mapper.ModelMapperConfig;
 import com.coopang.product.application.request.ProductStockDto;
 import com.coopang.product.application.service.ProductService;
 import com.coopang.product.presentation.request.AddStockRequest;
+import com.coopang.product.presentation.request.UpdateStockRequest;
+import jakarta.validation.Valid;
 import java.util.Map;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
@@ -27,7 +29,7 @@ public class ProductStockController {
     @Secured({"ROLE_MASTER","ROLE_HUB_MANAGER","ROLE_COMPANY"})
     @PatchMapping("/{productId}/restock")
     public ResponseEntity<?> addProductStock(@PathVariable UUID productId,
-        @RequestBody AddStockRequest addStockRequest) {
+        @Valid @RequestBody AddStockRequest addStockRequest) {
 
         ProductStockDto productStockDto = mapperConfig.strictMapper().map(addStockRequest, ProductStockDto.class);
 
@@ -40,11 +42,13 @@ public class ProductStockController {
     @PatchMapping("/{productId}/reduce")
     public ResponseEntity<String> reduceProductStock(
         @PathVariable UUID productId,
-        @PathVariable UUID productStockId,
-        @RequestBody Map<String, Object> stockUpdateRequest) {
+        @Valid @RequestBody UpdateStockRequest updateStockRequest) {
         // 상품 재고 수량 변경 로직
+        ProductStockDto productStockDto = mapperConfig.strictMapper().map(updateStockRequest, ProductStockDto.class);
 
-        return ResponseEntity.ok("Stock updated successfully");
+        productService.reduceProductStock(productId,updateStockRequest);
+
+        return new ResponseEntity<>(HttpStatus.NO_CONTENT);
     }
 
     @Secured({"ROLE_MASTER","ROLE_HUB_MANAGER","ROLE_COMPANY"})

--- a/BOOT/product/src/main/java/com/coopang/product/presentation/controller/ProductStockController.java
+++ b/BOOT/product/src/main/java/com/coopang/product/presentation/controller/ProductStockController.java
@@ -52,27 +52,4 @@ public class ProductStockController {
 
         return new ResponseEntity<>(HttpStatus.NO_CONTENT);
     }
-
-    @Secured({"ROLE_MASTER","ROLE_HUB_MANAGER","ROLE_COMPANY"})
-    @PatchMapping("/{productId}/rollback-increase")
-    public ResponseEntity<?> increaseProductStockByRollback(
-        @PathVariable UUID productId,
-        @PathVariable UUID productStockId,
-        @RequestBody Map<String, Object> stockUpdateRequest) {
-        // 상품 재고 수량 변경 로직
-
-        return ResponseEntity.ok("Stock updated successfully");
-    }
-
-    @Secured({"ROLE_MASTER","ROLE_HUB_MANAGER","ROLE_COMPANY"})
-    @PatchMapping("/{productId}/cancel-increase")
-    public ResponseEntity<String> increaseProductStockByCancel(
-        @PathVariable UUID productId,
-        @PathVariable UUID productStockId,
-        @RequestBody Map<String, Object> stockUpdateRequest) {
-        // 상품 재고 수량 변경 로직
-
-        return ResponseEntity.ok("Stock updated successfully");
-    }
-
 }

--- a/BOOT/product/src/main/java/com/coopang/product/presentation/controller/ProductStockController.java
+++ b/BOOT/product/src/main/java/com/coopang/product/presentation/controller/ProductStockController.java
@@ -48,7 +48,7 @@ public class ProductStockController {
         // 상품 재고 수량 변경 로직
         ProductStockDto productStockDto = mapperConfig.strictMapper().map(updateStockRequest, ProductStockDto.class);
 
-        productService.reduceProductStock(productId,updateStockRequest);
+        productService.reduceProductStock(productId,productStockDto);
 
         return new ResponseEntity<>(HttpStatus.NO_CONTENT);
     }

--- a/BOOT/product/src/main/java/com/coopang/product/presentation/controller/ProductStockHistoryController.java
+++ b/BOOT/product/src/main/java/com/coopang/product/presentation/controller/ProductStockHistoryController.java
@@ -1,10 +1,9 @@
 package com.coopang.product.presentation.controller;
 
 import com.coopang.apiconfig.mapper.ModelMapperConfig;
-import com.coopang.product.application.request.ProductStockDto;
 import com.coopang.product.application.request.ProductStockHistoryDto;
 import com.coopang.product.application.service.ProductService;
-import com.coopang.product.presentation.request.AddStockRequest;
+import com.coopang.product.presentation.request.ProductStockHistorySearchCondition;
 import com.coopang.product.presentation.request.UpdateStockHistoryRequest;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
@@ -16,8 +15,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.annotation.Secured;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.Mapping;
-import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -37,22 +35,22 @@ public class ProductStockHistoryController {
     private static final String USER_ID_HEADER = "X-User-Id";
     private static final String USER_ROLE_HEADER = "X-User-Role";
 
-
     @Secured({"ROLE_MASTER","ROLE_HUB_MANAGER","ROLE_COMPANY"})
     @GetMapping("/{productId}/product-stock-history")
     public ResponseEntity<?> getStockHistoriesByProductId(@PathVariable UUID productId, Pageable pageable) {
 
-        return new ResponseEntity<>(HttpStatus.OK);
+        return new ResponseEntity<>(productService.getStockHistoriesByProductId(productId,pageable),HttpStatus.OK);
     }
 
     @Secured({"ROLE_MASTER","ROLE_HUB_MANAGER","ROLE_COMPANY"})
-    @GetMapping("/{productId}/product-stock-history")
-    public ResponseEntity<?> getStockHistoriesByProductIdWithCondition(@PathVariable UUID productId, Pageable pageable) {
+    @GetMapping("/{productId}/product-stock-history/search")
+    public ResponseEntity<?> getStockHistoriesByProductIdWithCondition(@ModelAttribute
+    ProductStockHistorySearchCondition condition,@PathVariable UUID productId, Pageable pageable) {
 
-        return new ResponseEntity<>(HttpStatus.OK);
+        return new ResponseEntity<>(productService.getStockHistoriesByProductIdWithCondition(condition,productId,pageable),HttpStatus.OK);
     }
 
-    @Secured({"ROLE_MASTER","ROLE_HUB_MANAGER","ROLE_COMPANY"})
+    @Secured({"ROLE_MASTER","ROLE_HUB_MANAGER"})
     @PutMapping("/{productId}/product-stock-history/{productStockHistoryId}")
     public ResponseEntity<?> updateProductStockHistory(@PathVariable UUID productId, @PathVariable UUID productStockHistoryId,
         @RequestBody @Valid UpdateStockHistoryRequest request) {
@@ -63,13 +61,11 @@ public class ProductStockHistoryController {
         return new ResponseEntity<>(HttpStatus.NO_CONTENT);
     }
 
-    @Secured({"ROLE_MASTER","ROLE_HUB_MANAGER","ROLE_COMPANY"})
-    @DeleteMapping("/{productId}/product-stock-history/{productStockHistoryId")
-    public ResponseEntity<?> deleteProductStockHistoryById(@PathVariable UUID productId, @PathVariable UUID productStockHistoryId,
-        @RequestHeader(USER_ID_HEADER) UUID userId,
-        @RequestHeader(USER_ROLE_HEADER) String role) {
+    @Secured({"ROLE_MASTER","ROLE_HUB_MANAGER"})
+    @DeleteMapping("/{productId}/product-stock-history/{productStockHistoryId}")
+    public ResponseEntity<?> deleteProductStockHistoryById(@PathVariable UUID productId, @PathVariable UUID productStockHistoryId) {
 
-        productService.deleteProductStockHistory(productId,productStockHistoryId,userId,role);
+        productService.deleteProductStockHistory(productId,productStockHistoryId);
         return new ResponseEntity<>(HttpStatus.NO_CONTENT);
     }
 }

--- a/BOOT/product/src/main/java/com/coopang/product/presentation/controller/ProductStockHistoryController.java
+++ b/BOOT/product/src/main/java/com/coopang/product/presentation/controller/ProductStockHistoryController.java
@@ -1,10 +1,75 @@
 package com.coopang.product.presentation.controller;
 
+import com.coopang.apiconfig.mapper.ModelMapperConfig;
+import com.coopang.product.application.request.ProductStockDto;
+import com.coopang.product.application.request.ProductStockHistoryDto;
+import com.coopang.product.application.service.ProductService;
+import com.coopang.product.presentation.request.AddStockRequest;
+import com.coopang.product.presentation.request.UpdateStockHistoryRequest;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.annotation.Secured;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.Mapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+@Tag(name = "ProductStockHistoryController API", description = "ProductStockHistoryController API")
 @RestController
-@RequestMapping("/product-stock-histories/v1")
+@RequestMapping("/product-stock-histories/v1/product")
+@RequiredArgsConstructor
 public class ProductStockHistoryController {
 
+    private final ProductService productService;
+    private final ModelMapperConfig mapperConfig;
+
+    private static final String USER_ID_HEADER = "X-User-Id";
+    private static final String USER_ROLE_HEADER = "X-User-Role";
+
+
+    @Secured({"ROLE_MASTER","ROLE_HUB_MANAGER","ROLE_COMPANY"})
+    @GetMapping("/{productId}/product-stock-history")
+    public ResponseEntity<?> getStockHistoriesByProductId(@PathVariable UUID productId, Pageable pageable) {
+
+        return new ResponseEntity<>(HttpStatus.OK);
+    }
+
+    @Secured({"ROLE_MASTER","ROLE_HUB_MANAGER","ROLE_COMPANY"})
+    @GetMapping("/{productId}/product-stock-history")
+    public ResponseEntity<?> getStockHistoriesByProductIdWithCondition(@PathVariable UUID productId, Pageable pageable) {
+
+        return new ResponseEntity<>(HttpStatus.OK);
+    }
+
+    @Secured({"ROLE_MASTER","ROLE_HUB_MANAGER","ROLE_COMPANY"})
+    @PutMapping("/{productId}/product-stock-history/{productStockHistoryId}")
+    public ResponseEntity<?> updateProductStockHistory(@PathVariable UUID productId, @PathVariable UUID productStockHistoryId,
+        @RequestBody @Valid UpdateStockHistoryRequest request) {
+
+        ProductStockHistoryDto productStockHistoryDto = mapperConfig.strictMapper().map(request, ProductStockHistoryDto.class);
+        productService.updateProductStockHistory(productStockHistoryDto,productId,productStockHistoryId);
+
+        return new ResponseEntity<>(HttpStatus.NO_CONTENT);
+    }
+
+    @Secured({"ROLE_MASTER","ROLE_HUB_MANAGER","ROLE_COMPANY"})
+    @DeleteMapping("/{productId}/product-stock-history/{productStockHistoryId")
+    public ResponseEntity<?> deleteProductStockHistoryById(@PathVariable UUID productId, @PathVariable UUID productStockHistoryId,
+        @RequestHeader(USER_ID_HEADER) UUID userId,
+        @RequestHeader(USER_ROLE_HEADER) String role) {
+
+        productService.deleteProductStockHistory(productId,productStockHistoryId,userId,role);
+        return new ResponseEntity<>(HttpStatus.NO_CONTENT);
+    }
 }

--- a/BOOT/product/src/main/java/com/coopang/product/presentation/controller/ProductStockHistoryController.java
+++ b/BOOT/product/src/main/java/com/coopang/product/presentation/controller/ProductStockHistoryController.java
@@ -19,7 +19,6 @@ import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 

--- a/BOOT/product/src/main/java/com/coopang/product/presentation/request/AddStockRequest.java
+++ b/BOOT/product/src/main/java/com/coopang/product/presentation/request/AddStockRequest.java
@@ -1,0 +1,12 @@
+package com.coopang.product.presentation.request;
+
+import jakarta.validation.constraints.PositiveOrZero;
+import lombok.Getter;
+import lombok.Setter;
+
+@Setter
+@Getter
+public class AddStockRequest {
+    @PositiveOrZero(message = "Product Stock must be positive")
+    private int amount;
+}

--- a/BOOT/product/src/main/java/com/coopang/product/presentation/request/ProductStockHistorySearchCondition.java
+++ b/BOOT/product/src/main/java/com/coopang/product/presentation/request/ProductStockHistorySearchCondition.java
@@ -1,0 +1,13 @@
+package com.coopang.product.presentation.request;
+
+import com.coopang.product.domain.entity.ProductStockHistoryChangeType;
+import java.time.LocalDateTime;
+
+public record ProductStockHistorySearchCondition(
+    ProductStockHistoryChangeType changeType,
+    LocalDateTime startDate,
+    LocalDateTime endDate
+
+) {
+
+}

--- a/BOOT/product/src/main/java/com/coopang/product/presentation/request/UpdateStockHistoryRequest.java
+++ b/BOOT/product/src/main/java/com/coopang/product/presentation/request/UpdateStockHistoryRequest.java
@@ -2,6 +2,7 @@ package com.coopang.product.presentation.request;
 
 import com.coopang.product.domain.entity.ProductStockHistoryChangeType;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.PositiveOrZero;
 import lombok.Getter;
 import lombok.Setter;
@@ -18,6 +19,6 @@ public class UpdateStockHistoryRequest {
     private int productStockHistoryCurrentQuantity;
     @NotBlank
     private String productStockHistoryAdditionalInfo;
-    @NotBlank
+    @NotNull
     private ProductStockHistoryChangeType productStockHistoryChangeType;
 }

--- a/BOOT/product/src/main/java/com/coopang/product/presentation/request/UpdateStockHistoryRequest.java
+++ b/BOOT/product/src/main/java/com/coopang/product/presentation/request/UpdateStockHistoryRequest.java
@@ -1,0 +1,23 @@
+package com.coopang.product.presentation.request;
+
+import com.coopang.product.domain.entity.ProductStockHistoryChangeType;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.PositiveOrZero;
+import lombok.Getter;
+import lombok.Setter;
+
+@Setter
+@Getter
+public class UpdateStockHistoryRequest {
+
+    @PositiveOrZero(message = "수량은 양수로 입력해야됩니다.")
+    private int productStockHistoryChangeQuantity;
+    @PositiveOrZero(message = "수량은 양수로 입력해야됩니다.")
+    private int productStockHistoryPreviousQuantity;
+    @PositiveOrZero(message = "수량은 양수로 입력해야됩니다.")
+    private int productStockHistoryCurrentQuantity;
+    @NotBlank
+    private String productStockHistoryAdditionalInfo;
+    @NotBlank
+    private ProductStockHistoryChangeType productStockHistoryChangeType;
+}

--- a/BOOT/product/src/main/java/com/coopang/product/presentation/request/UpdateStockRequest.java
+++ b/BOOT/product/src/main/java/com/coopang/product/presentation/request/UpdateStockRequest.java
@@ -1,0 +1,15 @@
+package com.coopang.product.presentation.request;
+
+import jakarta.validation.constraints.PositiveOrZero;
+import java.util.UUID;
+import lombok.Getter;
+import lombok.Setter;
+
+@Setter
+@Getter
+public class UpdateStockRequest {
+
+    @PositiveOrZero(message = "Product Stock must be positive")
+    private int amount;
+    private UUID orderId;
+}


### PR DESCRIPTION
## 연관된 이슈
* Related - #49 
## 작업 상세내용
* API명세서를 토대로 상품 재고, 상품 재고 기록관련 CRUD 생성
## 리뷰 요청사항
*  상품 재고 증가 및 감소 시 낙관적 락을 이용해서 동시성 이슈 문제 해결
*  낙관적 락을 사용한 이유
    * 데이터 충돌이 적을 것이라고 생각(업체 및 허브관리자에서 주문 부족알림을 받은 뒤 재고 수량을 증가하거나 상품 재고가 이상할 경우 재고감소를 요청)
    * 주문 성공 시에는 카프카를 이용해서 할 예정
@coderabbitai review

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
  - 제품 재고 관리 및 이력 조회를 위한 새 DTO 및 레코드 추가.
  - 제품 재고 추가 및 감소를 위한 API 엔드포인트 추가.
  - 제품 재고 이력 CRUD 작업을 위한 새로운 API 메서드 추가.

- **버그 수정**
  - 재고 업데이트 시 최적의 잠금 실패를 처리하기 위한 재시도 로직 개선.

- **문서화**
  - API 문서화 메타데이터 추가 및 요청 매핑 업데이트.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->