### PR TITLE
Enforce unique product stock history and guard against duplicate stock messages

### DIFF
--- a/BOOT/product/src/main/java/com/coopang/product/domain/entity/productstockhistory/ProductStockHistoryEntity.java
+++ b/BOOT/product/src/main/java/com/coopang/product/domain/entity/productstockhistory/ProductStockHistoryEntity.java
@@ -12,6 +12,7 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -23,7 +24,13 @@ import java.util.UUID;
 
 @Getter
 @Entity
-@Table(name = "p_product_stock_histories")
+@Table(
+    name = "p_product_stock_histories",
+    uniqueConstraints = @UniqueConstraint(
+        name = "uk_product_stock_history_order_change",
+        columnNames = {"product_stock_id", "order_id", "product_stock_history_change_type"}
+    )
+)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @EntityListeners(value = {AuditingEntityListener.class})
 @SQLRestriction("is_deleted = false")

--- a/BOOT/product/src/main/java/com/coopang/product/domain/repository/productstockhistory/ProductStockHistoryRepository.java
+++ b/BOOT/product/src/main/java/com/coopang/product/domain/repository/productstockhistory/ProductStockHistoryRepository.java
@@ -1,5 +1,6 @@
 package com.coopang.product.domain.repository.productstockhistory;
 
+import com.coopang.product.domain.entity.productstockhistory.ProductStockHistoryChangeType;
 import com.coopang.product.domain.entity.productstockhistory.ProductStockHistoryEntity;
 import com.coopang.product.presentation.request.productstockhistory.ProductStockHistorySearchConditionDto;
 import org.springframework.data.domain.Page;
@@ -14,4 +15,10 @@ public interface ProductStockHistoryRepository {
     Page<ProductStockHistoryEntity> searchProductStockHistoryByProductId(ProductStockHistorySearchConditionDto condition, UUID productId, Pageable pageable);
 
     Optional<ProductStockHistoryEntity> findByProductStockHistoryIdAndProductStockEntity_ProductStockId(UUID productStockHistoryId, UUID productStockId);
+
+    boolean existsByProductStockEntity_ProductStockIdAndOrderIdAndProductStockHistoryChangeType(
+        UUID productStockId,
+        UUID orderId,
+        ProductStockHistoryChangeType productStockHistoryChangeType
+    );
 }


### PR DESCRIPTION
### Motivation
- Prevent duplicate stock-history records for the same `product_stock_id` + `order_id` + `product_stock_history_change_type` combination to avoid double-applying stock changes.
- Provide a repository-level existence check to detect prior history events before mutating stock.
- Avoid repeated stock changes caused by duplicate messages by short-circuiting service operations and logging the event.

### Description
- Add a table uniqueness constraint in `ProductStockHistoryEntity` via `@Table(..., uniqueConstraints = @UniqueConstraint(...))` named `uk_product_stock_history_order_change` on `product_stock_id`, `order_id`, and `product_stock_history_change_type`.
- Add repository method `existsByProductStockEntity_ProductStockIdAndOrderIdAndProductStockHistoryChangeType(...)` to `ProductStockHistoryRepository` for existence checks.
- Inject `ProductStockHistoryRepository` into `ProductStockService` and add early-return guards with informational `log.info(...)` in `reduceProductStock`, `rollbackProduct`, and `cancelProduct` when a corresponding history entry already exists.

### Testing
- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6950d25337e08333bbf271d11024dac9)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * 재고 감소(주문 처리), 롤백, 취소 작업에 대해 중복 메시지 재처리를 방지하는 중복 감지 로직을 추가했습니다.
  * 재고 변경 이력에 대해 주문·유형별 중복 저장을 차단하는 일관성 검사(존재 확인)와 데이터 무결성 제약을 도입했습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->